### PR TITLE
Исправление ошибки с падением на Mac OS X

### DIFF
--- a/dev/build.sh
+++ b/dev/build.sh
@@ -7,9 +7,6 @@
 # $URL: svn://opensvn.ru/avalon/trunk/dev/build.sh $
 ###
 
-# путь до Qt4.4 без слеша в конце
-QT_PATH="/usr/lib/qt4"
-
 # имя проекта
 PROJECT_NAME="avalon"
 
@@ -27,10 +24,10 @@ rm -f version.tmp
 make clean
 
 # создание pro-файла
-${QT_PATH}/bin/qmake -project -recursive -Wall -o ${PROJECT_NAME}.pro "CONFIG += debug_and_release" "QT += network sql webkit" "LIBS += -laspell"
+qmake -project -recursive -Wall -o ${PROJECT_NAME}.pro "CONFIG += debug_and_release" "QT += network sql webkit" "LIBS += -laspell -lz"
 
 # создание make-файлов
-${QT_PATH}/bin/qmake ${PROJECT_NAME}.pro
+qmake ${PROJECT_NAME}.pro
 
 # создание бинарника
 make $1

--- a/parser.cpp
+++ b/parser.cpp
@@ -479,7 +479,7 @@ QString AParser::formatMessage (const AMessageInfo& message, bool special, bool 
 		// игнорируем простые тэги
 		AStrongTag* found_tag = NULL;
 
-		for (size_t i = 0; i < sizeof(g_strong_tags) / sizeof(QString); i++)
+        for (size_t i = 0; i < sizeof(g_strong_tags) / sizeof(AStrongTag); i++)
 			if (tag == g_strong_tags[i].OpenTag)
 			{
 				found_tag = &g_strong_tags[i];


### PR DESCRIPTION
- Исправление ошибки с падением на Mac OS X (Issue #26). Полагаю, она вопроизводится и на других платформах.
- В dev/build.sh совершенно ни к чему привязываться к жесткому расположению qmake, на UNIX-like системах он в любом случае будет в PATH.
